### PR TITLE
Set HTMLElement's base type to DOMNode, and DOMNode's base type to object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ module.exports = {
 
     expect.addType({
       name: 'DOMNode',
+      base: 'object',
       identify: function (obj) {
         if (!obj) {
           return false;
@@ -82,6 +83,7 @@ module.exports = {
 
     expect.addType({
       name: 'HTMLElement',
+      base: 'DOMNode',
       identify: function (obj) {
         if (!obj) {
           return false;

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -18,6 +18,10 @@ describe('unexpected-dom', function () {
     });
   });
 
+  it('should allow regular assertions defined for the object type to work on an HTMLElement', function () {
+    expect(jsdom.jsdom('<html><head></head><body></body></html>').firstChild, 'to have properties', { nodeType: 1 });
+  });
+
   it('should consider two DOM elements equal when they are of same type and have same attributes', function () {
     var document = this.document;
 


### PR DESCRIPTION
This makes all the regular 'object' assertions work for the types defined by unexpected-dom.