### PR TITLE
Html document type and "queried for" assertion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,22 @@ module.exports = {
       }
     });
 
+    expect.addType({
+      name: 'HTMLDocument',
+      base: 'DOMNode',
+      identify: function (obj) {
+        if ('HTMLDocument' in this) {
+          return obj instanceof HTMLDocument;
+        }
+
+        if (typeof window !== 'undefined') {
+          return obj instanceof window.HTMLDocument;
+        }
+
+        // Stupid duck typing case. Help :)
+        return obj && obj.documentElement && obj.implementation;
+      }
+    });
 
     expect.addType({
       name: 'HTMLElement',

--- a/lib/index.js
+++ b/lib/index.js
@@ -153,5 +153,9 @@ module.exports = {
         throw children;
       }
     });
+
+    expect.addAssertion(['HTMLDocument', 'HTMLElement'], 'queried for [first]', function (expect, subject, value) {
+      this.shift(expect, this.flags.first ? subject.querySelector(value) : subject.querySelectorAll(value), 1);
+    });
   }
 };

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -195,4 +195,15 @@ describe('unexpected-dom', function () {
     });
   });
 
+  describe('queried for', function () {
+    it('should work with HTMLDocument', function () {
+      var document = jsdom.jsdom('<!DOCTYPE html><html><body><div id="foo"></div></body></html>');
+      expect(document, 'queried for first', 'div', 'to have attributes', { id: 'foo' });
+    });
+
+    it('should work with HTMLElement', function () {
+      var document = jsdom.jsdom('<!DOCTYPE html><html><body><div id="foo"></div></body></html>');
+      expect(document.querySelector('body'), 'queried for first', 'div', 'to have attributes', { id: 'foo' });
+    });
+  });
 });


### PR DESCRIPTION
The `identify` function of `HTMLDocument` should probably be improved, but I had a little trouble understanding the overall strategy for detecting these instances in both the browser and jsdom.

`queried for` is the spike I mentioned on the unexpected gitter. It's one out of many possible takes on how to add querying support.