### PR TITLE
Update unexpeted to 7.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -374,13 +374,13 @@ module.exports = {
             }
           }
 
-          expect(attrs, 'to [exhaustively] satisfy', comparator);
+          return expect(attrs, 'to [exhaustively] satisfy', comparator);
         } else {
           if (cmp['class']) {
             comparator['class'] = expect.it.apply(null, ['to contain'].concat(cmpClasses));
           }
 
-          expect(attrs, 'to satisfy', comparator);
+          return expect(attrs, 'to satisfy', comparator);
         }
       } else {
         throw new Error('Please supply either strings, array, or object');

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": "0.0.2",
     "uglifyjs": "^2.4.10",
-    "unexpected": "^6.0.7"
+    "unexpected": "^7.0.1"
   },
   "dependencies": {
     "array-changes": "1.0.1",


### PR DESCRIPTION
... and be compatible with promise-returning `expect.it` assertions in 'to satisfy' specs.