### PR TITLE
Expect attribute to be absent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -562,7 +562,9 @@ module.exports = {
                 return topLevelExpect(attrs.style, 'to satisfy', expectedStyleObj);
               }
             } else if (expectedAttributeValue === true) {
-              expect(subject.hasAttribute(attributeName), 'to be true');
+              topLevelExpect(subject.hasAttribute(attributeName), 'to be true');
+            } else if (typeof expectedAttributeValue === 'undefined') {
+              topLevelExpect(subject.hasAttribute(attributeName), 'to be false');
             } else {
               return topLevelExpect(attributeValue, 'to satisfy', expectedAttributeValue);
             }
@@ -615,7 +617,7 @@ module.exports = {
                     output
                       .sp()
                       .annotationBlock(function () {
-                        if (promise) {
+                        if (promise && typeof expectedValueByAttributeName[attributeName] !== 'undefined') {
                           this.append(promise.reason().getErrorMessage());
                         } else {
                           // onlyAttributes === true

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mocha-lcov-reporter": "0.0.2",
     "sinon": "1.14.1",
     "uglifyjs": "^2.4.10",
-    "unexpected": "^8.0.0",
+    "unexpected": "^8.4.0",
     "unexpected-sinon": "^6.1.3"
   },
   "dependencies": {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -396,6 +396,27 @@ describe('unexpected-dom', function () {
           '>Press me</button>'
         );
       });
+
+      describe('with the absence of an attribute asserted by providing undefined as the expected value', function () {
+        it('should succeed', function () {
+          this.body.innerHTML = '<button id="foo">Press me</button>';
+          expect(this.body.firstChild, 'to have attributes', { quux: undefined });
+        });
+
+        it('should fail with a diff', function () {
+          this.body.innerHTML = '<button id="foo" quux="baz">Press me</button>';
+          var el = this.body.firstChild;
+
+          expect(function () {
+            expect(el, 'to have attributes', { quux: undefined });
+          }, 'to throw',
+            'expected <button id="foo" quux="baz">Press me</button> to have attributes { quux: undefined }\n' +
+            '\n' +
+            '<button id="foo" quux="baz" // should be removed\n' +
+            '>Press me</button>'
+          );
+        });
+      });
     });
 
     describe('object comparison', function () {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -762,7 +762,7 @@ describe('unexpected-dom', function () {
           '<div foo="bar">\n' +
           '  hey // expected NodeList[ hey ] to satisfy [ \'there\' ]\n' +
           '      //\n' +
-          '      // DOMNodeList[\n' +
+          '      // NodeList[\n' +
           '      //   hey // should equal \'there\'\n' +
           '      //       // -hey\n' +
           '      //       // +there\n' +
@@ -788,15 +788,14 @@ describe('unexpected-dom', function () {
         '  expected NodeList[ <div foo="bar" id="quux">foobar</div>, <div foo="quux">hey</div> ]\n' +
         '  to satisfy { 1: { attributes: { foo: \'bar\' } } }\n' +
         '\n' +
-        '  NodeList({\n' +
-        '    0: <div foo="bar" id="quux">...</div>,\n' +
-        '    1:\n' +
-        '      <div foo="quux" // expected \'quux\' to satisfy \'bar\'\n' +
-        '                      //\n' +
-        '                      // -quux\n' +
-        '                      // +bar\n' +
-        '      >hey</div>\n' +
-        '  })'
+        '  NodeList[\n' +
+        '    <div foo="bar" id="quux">...</div>,\n' +
+        '    <div foo="quux" // expected \'quux\' to satisfy \'bar\'\n' +
+        '                    //\n' +
+        '                    // -quux\n' +
+        '                    // +bar\n' +
+        '    >hey</div>\n' +
+        '  ]'
       );
     });
   });
@@ -866,7 +865,7 @@ describe('unexpected-dom', function () {
         expect(document, 'to contain no elements matching', '.foo');
       }, 'to throw', 'expected <!DOCTYPE html><html><head></head><body>...</body></html> to contain no elements matching \'.foo\'\n' +
           '\n' +
-          'DOMNodeList[\n' +
+          'NodeList[\n' +
           '  <div class="foo"></div> // should be removed\n' +
           ']'
       );
@@ -879,7 +878,7 @@ describe('unexpected-dom', function () {
         expect(document, 'to contain no elements matching', '.foo');
       }, 'to throw', 'expected <!DOCTYPE html><html><head></head><body>...</body></html> to contain no elements matching \'.foo\'\n' +
           '\n' +
-          'DOMNodeList[\n' +
+          'NodeList[\n' +
           '  <div class="foo"></div>, // should be removed\n' +
           '  <div class="foo"></div> // should be removed\n' +
           ']'


### PR DESCRIPTION
For some reason it was never possible to assert that an attribute is absent by going:

```js
expect(element, 'to have attributes', { foo: undefined });
// or:
expect(element, 'to satisfy', { attributes: { foo: undefined } });
```

Analogous to the object `to satisfy` semantics.

This PR fixes that and adds tests.