### PR TITLE
Add 'to have elements matching' assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,33 @@ Tests the text content of a DOM element
 expect(node, 'to have text', 'foo');
 ```
 
+**To contain [no] elements matching**
+
+Tests that the DOMElement has (no) elements matching the given selector
+
+```js
+
+// node = '<div> <span class="exists">sample</span> </div>'
+
+expect(node, 'to contain elements matching', '.exists');
+expect(node, 'to contain no elements matching', '.not-exists');
+```
+
+
 **To have children**
+
+Tests the children of the DOMElement
+
+```js
+
+// node = '<div> <span class="one">sample</span><span class="two">sample2</span> </div>'
+
+expect(node, 'to have children', [
+  expect.it('to have attributes', { class: 'one' }),
+  expect.it('to have attributes', { class: 'two' })
+]);
+```
+
 
 **Queried for**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -740,8 +740,11 @@ module.exports = {
       return this.shift(expect, queryResult, 1);
     });
 
-    expect.addAssertion(['DOMDocument', 'DOMElement'], 'to contain no elements matching', function (expect, subject, value) {
-      return expect(subject.querySelectorAll(value), 'to satisfy', []);
+    expect.addAssertion(['DOMDocument', 'DOMElement'], 'to contain [no] elements matching', function (expect, subject, value) {
+      if (this.flags.no) {
+        return expect(subject.querySelectorAll(value), 'to satisfy', []);
+      }
+      return expect(subject.querySelectorAll(value), 'not to satisfy', []);
     });
 
     expect.addAssertion(['DOMDocument', 'DOMElement'], '[not] to match', function (expect, subject, value) {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -907,6 +907,22 @@ describe('unexpected-dom', function () {
     });
   });
 
+  describe('to contain elements matching', function () {
+    it('should pass when matching an element', function () {
+      var document = jsdom.jsdom('<!DOCTYPE html><html><body><div class="foo"></div></body></html>');
+
+      expect(document, 'to contain elements matching', '.foo');
+    });
+
+    it('should fail when no elements match', function () {
+      var document = jsdom.jsdom('<!DOCTYPE html><html><body><div class="foo"></div><div class="foo"></div></body></html>');
+
+      expect(function () {
+          expect(document, 'to contain elements matching', '.bar');
+        }, 'to throw', 'expected <!DOCTYPE html><html><head></head><body>...</body></html> to contain elements matching \'.bar\'');
+    });
+  });
+
   describe('to match', function () {
     it('should match an element correctly', function () {
       var document = jsdom.jsdom('<!DOCTYPE html><html><body><div class="foo"></div></body></html>');


### PR DESCRIPTION
This is a variant of the 'to have no elements matching',
via a flag. 

README.md updated with examples, and included
examples of 'to have children', as that was also 
undocumented.