### PR TITLE
Consider surrounding whitespace when comparing text nodes for equality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -267,7 +267,7 @@ module.exports = {
         return obj && typeof obj.nodeType === 'number' && obj.nodeType === 3;
       },
       equal: function (a, b) {
-        return a.nodeValue.trim() === b.nodeValue.trim();
+        return a.nodeValue === b.nodeValue;
       },
       inspect: function (element, depth, output) {
         return output.code(entitify(element.nodeValue.trim()), 'html');


### PR DESCRIPTION
We might need a way to tolerate whitespace difference and the like, but in any case, this is not the correct way to accomplish that.

As per the discussion on the Unexpected gitter channel.