### PR TITLE
Fixed detection of HTML/XML in Safari and IE.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,8 +93,17 @@ function getClassNamesFromAttributeValue(attributeValue) {
   return classNames;
 }
 
+function isInsideHtmlDocument(node) {
+  var ownerDocument = node.ownerDocument;
+  if (ownerDocument.contentType) {
+    return ownerDocument.contentType === 'text/html';
+  } else {
+    return ownerDocument.toString() === '[object HTMLDocument]';
+  }
+}
+
 function getAttributes(element) {
-  var isHtml = element.ownerDocument.contentType === 'text/html';
+  var isHtml = isInsideHtmlDocument(element);
   var attrs = element.attributes;
   var result = {};
 
@@ -175,7 +184,7 @@ function stringifyStartTag(element) {
 }
 
 function stringifyEndTag(element) {
-  var isHtml = element.ownerDocument.contentType === 'text/html';
+  var isHtml = isInsideHtmlDocument(element);
   var elementName = isHtml ? element.nodeName.toLowerCase() : element.nodeName;
   if (isHtml && isVoidElement(elementName) && element.childNodes.length === 0) {
     return '';
@@ -399,7 +408,13 @@ module.exports = {
         return obj && typeof obj.nodeType === 'number' && obj.nodeType === 1 && obj.nodeName && obj.attributes;
       },
       equal: function (a, b, equal) {
-        return a.nodeName.toLowerCase() === b.nodeName.toLowerCase() && equal(getAttributes(a), getAttributes(b)) && equal(a.childNodes, b.childNodes);
+        var aIsHtml = isInsideHtmlDocument(a);
+        var bIsHtml = isInsideHtmlDocument(b);
+        return (
+          aIsHtml === bIsHtml &&
+          (aIsHtml ? a.nodeName.toLowerCase() === b.nodeName.toLowerCase() : a.nodeName === b.nodeName) &&
+          equal(getAttributes(a), getAttributes(b)) && equal(a.childNodes, b.childNodes)
+        );
       },
       inspect: function (element, depth, output, inspect) {
         var elementName = element.nodeName.toLowerCase();
@@ -453,7 +468,7 @@ module.exports = {
       },
       diffLimit: 512,
       diff: function (actual, expected, output, diff, inspect, equal) {
-        var isHtml = actual.ownerDocument.contentType === 'text/html';
+        var isHtml = isInsideHtmlDocument(actual);
         var result = {
           diff: output,
           inline: true
@@ -572,7 +587,7 @@ module.exports = {
     }
 
     expect.addAssertion('DOMDocumentFragment', 'to [exhaustively] satisfy', function (expect, subject, value) {
-      var isHtml = subject.ownerDocument.contentType === 'text/html';
+      var isHtml = isInsideHtmlDocument(subject);
       var valueType = expect.findTypeOf(value);
       if (valueType.name === 'string') {
         var originalValue = value;
@@ -592,7 +607,7 @@ module.exports = {
     });
 
     expect.addAssertion('DOMElement', 'to [exhaustively] satisfy', function (expect, subject, value) {
-      var isHtml = subject.ownerDocument.contentType === 'text/html';
+      var isHtml = isInsideHtmlDocument(subject);
       if (typeof value === 'string') {
         var documentFragment = isHtml ? parseHtml(value, true, this.testDescription) : parseXml(value, this.testDescription);
         if (documentFragment.childNodes.length !== 1) {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -50,6 +50,14 @@ function parseHtmlFragment(str) {
   return documentFragment;
 }
 
+function parseXml(str) {
+  if (typeof DOMParser !== 'undefined') {
+    return new DOMParser().parseFromString(str, 'text/xml');
+  } else {
+    return require('jsdom').jsdom(str, { parsingMode: 'xml' });
+  }
+}
+
 describe('unexpected-dom', function () {
   expect.output.preferredWidth = 100;
 
@@ -1673,6 +1681,49 @@ describe('unexpected-dom', function () {
       '    </span>\n' +
       '  </li>\n' +
       '</ul>'
+    );
+  });
+
+  it('should compare XML element names case sensitively', function () {
+    expect(function () {
+      expect(parseXml('<foO></foO>').firstChild, 'to satisfy', {
+        name: 'foo'
+      });
+    }, 'to throw',
+      'expected <foO></foO> to satisfy { name: \'foo\' }\n' +
+      '\n' +
+      '<foO // should equal \'foo\'\n' +
+      '></foO>'
+    );
+  });
+
+  it('should compare XML element names case sensitively, even when the owner document lacks a contentType attribute', function () {
+    expect(function () {
+      var document = parseXml('<foO></foO>');
+      document.firstChild._ownerDocument = { toString: function () { return '[object XMLDocument]'; } };
+      expect(document.firstChild, 'to satisfy', {
+        name: 'foo'
+      });
+    }, 'to throw',
+      'expected <foO></foO> to satisfy { name: \'foo\' }\n' +
+      '\n' +
+      '<foO // should equal \'foo\'\n' +
+      '></foO>'
+    );
+  });
+
+  it('should compare XML element names case sensitively, even when the owner document lacks a contentType attribute', function () {
+    expect(function () {
+      var document = parseXml('<foO></foO>');
+      document.firstChild._ownerDocument = { toString: function () { return '[object XMLDocument]'; } };
+      expect(document.firstChild, 'to satisfy', {
+        name: 'foo'
+      });
+    }, 'to throw',
+      'expected <foO></foO> to satisfy { name: \'foo\' }\n' +
+      '\n' +
+      '<foO // should equal \'foo\'\n' +
+      '></foO>'
     );
   });
 });


### PR DESCRIPTION
DOMElement equal: Made node name comparisons case sensitive in XML documents.

Fixes #32.