### PR TITLE
Update to Unexpected 10

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -599,7 +599,7 @@ module.exports = {
       }
     }
 
-    expect.addAssertion('<DOMNodeList> to [exhaustively] satisfy <string>', function (expect, subject, value) {
+    expect.addAssertion('<DOMNodeList|attachedDOMNodeList> to [exhaustively] satisfy <string>', function (expect, subject, value) {
       var isHtml = subject.ownerDocument.contentType === 'text/html';
       expect.argsOutput = function (output) {
         output.code(value, isHtml ? 'html' : 'xml');
@@ -607,7 +607,7 @@ module.exports = {
       return expect(subject, 'to [exhaustively] satisfy', (isHtml ? parseHtml(value, true, expect.testDescription) : parseXml(value, expect.testDescription)).childNodes);
     });
 
-    expect.addAssertion('<DOMNodeList> to [exhaustively] satisfy <DOMNodeList>', function (expect, subject, value) {
+    expect.addAssertion('<DOMNodeList|attachedDOMNodeList> to [exhaustively] satisfy <DOMNodeList>', function (expect, subject, value) {
       var isHtml = subject.ownerDocument.contentType === 'text/html';
       var satisfySpecs = [];
       for (var i = 0 ; i < value.length ; i += 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -895,6 +895,10 @@ module.exports = {
     expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> [when] queried for [first] <string> <assertion?>', function (expect, subject, query) {
       var queryResult;
 
+      expect.argsOutput[0] = function (output) {
+        return output.green(query);
+      };
+
       expect.errorMode = 'nested';
 
       if (expect.flags.first) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -599,7 +599,7 @@ module.exports = {
       }
     }
 
-    expect.addAssertion('<DOMNodeList|attachedDOMNodeList> to [exhaustively] satisfy <string>', function (expect, subject, value) {
+    expect.addAssertion('<DOMNodeList> to [exhaustively] satisfy <string>', function (expect, subject, value) {
       var isHtml = subject.ownerDocument.contentType === 'text/html';
       expect.argsOutput = function (output) {
         output.code(value, isHtml ? 'html' : 'xml');
@@ -607,7 +607,7 @@ module.exports = {
       return expect(subject, 'to [exhaustively] satisfy', (isHtml ? parseHtml(value, true, expect.testDescription) : parseXml(value, expect.testDescription)).childNodes);
     });
 
-    expect.addAssertion('<DOMNodeList|attachedDOMNodeList> to [exhaustively] satisfy <DOMNodeList>', function (expect, subject, value) {
+    expect.addAssertion('<DOMNodeList> to [exhaustively] satisfy <DOMNodeList>', function (expect, subject, value) {
       var isHtml = subject.ownerDocument.contentType === 'text/html';
       var satisfySpecs = [];
       for (var i = 0 ; i < value.length ; i += 1) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -892,7 +892,7 @@ module.exports = {
       return expect(subject.textContent, 'to satisfy', value);
     });
 
-    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> queried for [first] <assertion>', function (expect, subject, query) {
+    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> queried for [first] <string> <assertion>', function (expect, subject, query) {
       var queryResult;
 
       expect.errorMode = 'nested';
@@ -912,7 +912,7 @@ module.exports = {
           });
         }
       }
-      return expect.shift(queryResult, 1);
+      return expect.shift(queryResult);
     });
 
     expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> to contain [no] elements matching <string>', function (expect, subject, query) {
@@ -928,12 +928,12 @@ module.exports = {
 
     expect.addAssertion('<string> when parsed as (html|HTML) [fragment] <assertion>', function (expect, subject) {
       expect.errorMode = 'nested';
-      return expect.shift(parseHtml(subject, expect.flags.fragment, expect.testDescription), 0);
+      return expect.shift(parseHtml(subject, expect.flags.fragment, expect.testDescription));
     });
 
     expect.addAssertion('<string> when parsed as (xml|XML) <assertion>', function (expect, subject) {
       expect.errorMode = 'nested';
-      return expect.shift(parseXml(subject, expect.testDescription), 0);
+      return expect.shift(parseXml(subject, expect.testDescription));
     });
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -311,7 +311,7 @@ module.exports = {
     // Fake type to make it possible to build 'to satisfy' diffs to be rendered inline:
     expect.addType({
       name: 'attachedDOMNodeList',
-      base: 'array-like',
+      base: 'DOMNodeList',
       prefix: function (output) { return output; },
       suffix: function (output) { return output; },
       delimiter: function (output) { return output; },
@@ -319,6 +319,16 @@ module.exports = {
         return obj && obj._isAttachedDOMNodeList;
       }
     });
+
+    function makeAttachedDOMNodeList(domNodeList, contentType) {
+      var attachedDOMNodeList = [];
+      for (var i = 0 ; i < domNodeList.length ; i += 1) {
+        attachedDOMNodeList.push(domNodeList[i]);
+      }
+      attachedDOMNodeList._isAttachedDOMNodeList = true;
+      attachedDOMNodeList.ownerDocument = { contentType: contentType };
+      return attachedDOMNodeList;
+    }
 
     expect.addType({
       name: 'HTMLDocType',
@@ -559,6 +569,10 @@ module.exports = {
       return expect(subject.nodeValue, 'to equal', value.nodeValue);
     });
 
+    expect.addAssertion('<DOMTextNode> to [exhaustively] satisfy <object>', function (expect, subject, value) {
+      expect.fail();
+    });
+
     expect.addAssertion('<DOMTextNode> to [exhaustively] satisfy <any>', function (expect, subject, value) {
       return expect(subject.nodeValue, 'to satisfy', value);
     });
@@ -584,6 +598,23 @@ module.exports = {
         throw new Error('to satisfy: Node type ' + node.nodeType + ' is not yet supported in the value');
       }
     }
+
+    expect.addAssertion('<DOMNodeList> to [exhaustively] satisfy <string>', function (expect, subject, value) {
+      var isHtml = subject.ownerDocument.contentType === 'text/html';
+      expect.argsOutput = function (output) {
+        output.code(value, isHtml ? 'html' : 'xml');
+      };
+      return expect(subject, 'to [exhaustively] satisfy', (isHtml ? parseHtml(value, true, expect.testDescription) : parseXml(value, expect.testDescription)).childNodes);
+    });
+
+    expect.addAssertion('<DOMNodeList> to [exhaustively] satisfy <DOMNodeList>', function (expect, subject, value) {
+      var isHtml = subject.ownerDocument.contentType === 'text/html';
+      var satisfySpecs = [];
+      for (var i = 0 ; i < value.length ; i += 1) {
+        satisfySpecs.push(convertDOMNodeToSatisfySpec(value[i], isHtml));
+      }
+      return expect(subject, 'to [exhaustively] satisfy', satisfySpecs);
+    });
 
     expect.addAssertion('<DOMDocumentFragment> to [exhaustively] satisfy <string>', function (expect, subject, value) {
       var isHtml = isInsideHtmlDocument(subject);
@@ -620,6 +651,14 @@ module.exports = {
       return expect(subject, 'to [exhaustively] satisfy', convertDOMNodeToSatisfySpec(value, subject.ownerDocument.contentType === 'text/html'));
     });
 
+    expect.addAssertion('<DOMElement> to [exhaustively] satisfy <DOMTextNode>', function (expect, subject, value) {
+      expect.fail();
+    });
+
+    expect.addAssertion('<DOMTextNode> to [exhaustively] satisfy <DOMElement>', function (expect, subject, value) {
+      expect.fail();
+    });
+
     expect.addAssertion('<DOMElement> to [exhaustively] satisfy <object>', function (expect, subject, value) {
       var isHtml = subject.ownerDocument.contentType === 'text/html';
       var unsupportedOptions = Object.keys(value).filter(function (key) {
@@ -640,12 +679,7 @@ module.exports = {
             if (typeof value.textContent !== 'undefined') {
               throw new Error('The children and textContent properties are not supported together');
             }
-            var nodeListForDiffing = [];
-            for (var i = 0 ; i < subject.childNodes.length ; i += 1) {
-              nodeListForDiffing.push(subject.childNodes[i]);
-            }
-            nodeListForDiffing._isAttachedDOMNodeList = true;
-            return topLevelExpect(nodeListForDiffing, 'to satisfy', value.children);
+            return topLevelExpect(makeAttachedDOMNodeList(subject.childNodes, subject.ownerDocument.contentType), 'to satisfy', value.children);
           } else if (typeof value.textContent !== 'undefined') {
             return topLevelExpect(subject.textContent, 'to satisfy', value.textContent);
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -539,29 +539,28 @@ module.exports = {
       }
     });
 
-    expect.addAssertion('DOMElement', 'to [only] have (class|classes)', function (expect, subject, value) {
-      var flags = this.flags;
-      if (flags.only) {
-        return expect(subject, 'to have attributes', {
-          class: function (className) {
-            var actualClasses = getClassNamesFromAttributeValue(className);
-            if (typeof value === 'string') {
-              value = getClassNamesFromAttributeValue(value);
-            }
-            if (flags.only) {
-              return topLevelExpect(actualClasses.sort(), 'to equal', value.sort());
-            } else {
-              return topLevelExpect.apply(topLevelExpect, [actualClasses, 'to contain'].concat(value));
-            }
-          }
-        });
-      } else {
-        return expect(subject, 'to have attributes', { class: value });
-      }
+    expect.addAssertion('<DOMElement> to have (class|classes) <array|string>', function (expect, subject, value) {
+      return expect(subject, 'to have attributes', { class: value });
     });
 
-    expect.addAssertion('DOMTextNode', 'to [exhaustively] satisfy', function (expect, subject, value) {
-      return expect(subject.nodeValue, 'to satisfy', expect.findTypeOf(value).name === 'DOMTextNode' ? value.nodeValue : value);
+    expect.addAssertion('<DOMElement> to only have (class|classes) <array|string>', function (expect, subject, value) {
+      return expect(subject, 'to have attributes', {
+        class: function (className) {
+          var actualClasses = getClassNamesFromAttributeValue(className);
+          if (typeof value === 'string') {
+            value = getClassNamesFromAttributeValue(value);
+          }
+          return topLevelExpect(actualClasses.sort(), 'to equal', value.sort());
+        }
+      });
+    });
+
+    expect.addAssertion('<DOMTextNode> to [exhaustively] satisfy <DOMTextNode>', function (expect, subject, value) {
+      return expect(subject.nodeValue, 'to equal', value.nodeValue);
+    });
+
+    expect.addAssertion('<DOMTextNode> to [exhaustively] satisfy <any>', function (expect, subject, value) {
+      return expect(subject.nodeValue, 'to satisfy', value);
     });
 
     function convertDOMNodeToSatisfySpec(node, isHtml) {
@@ -586,49 +585,48 @@ module.exports = {
       }
     }
 
-    expect.addAssertion('DOMDocumentFragment', 'to [exhaustively] satisfy', function (expect, subject, value) {
+    expect.addAssertion('<DOMDocumentFragment> to [exhaustively] satisfy <string>', function (expect, subject, value) {
       var isHtml = isInsideHtmlDocument(subject);
-      var valueType = expect.findTypeOf(value);
-      if (valueType.name === 'string') {
-        var originalValue = value;
-        this.argsOutput = function (output) {
-          output.code(originalValue, isHtml ? 'html' : 'xml');
-        };
-        value = isHtml ? parseHtml(value, true, this.testDescription) : parseXml(value, this.testDescription);
-      }
+      expect.argsOutput = function (output) {
+        output.code(value, isHtml ? 'html' : 'xml');
+      };
+      return expect(subject, 'to [exhaustively] satisfy', isHtml ? parseHtml(value, true, expect.testDescription) : parseXml(value, expect.testDescription));
+    });
 
-      if (value && value.nodeType === 11) {
-        value = Array.prototype.map.call(value.childNodes, function (childNode) {
-          return convertDOMNodeToSatisfySpec(childNode, isHtml);
-        });
-      }
+    expect.addAssertion('<DOMDocumentFragment> to [exhaustively] satisfy <DOMDocumentFragment>', function (expect, subject, value) {
+      var isHtml = subject.ownerDocument.contentType === 'text/html';
+      return expect(subject, 'to [exhaustively] satisfy', Array.prototype.map.call(value.childNodes, function (childNode) {
+        return convertDOMNodeToSatisfySpec(childNode, isHtml);
+      }));
+    });
 
+    expect.addAssertion('<DOMDocumentFragment> to [exhaustively] satisfy <object|array>', function (expect, subject, value) {
       return expect(subject.childNodes, 'to [exhaustively] satisfy', value);
     });
 
-    expect.addAssertion('DOMElement', 'to [exhaustively] satisfy', function (expect, subject, value) {
+    expect.addAssertion('<DOMElement> to [exhaustively] satisfy <string>', function (expect, subject, value) {
       var isHtml = isInsideHtmlDocument(subject);
-      if (typeof value === 'string') {
-        var documentFragment = isHtml ? parseHtml(value, true, this.testDescription) : parseXml(value, this.testDescription);
-        if (documentFragment.childNodes.length !== 1) {
-          throw new Error('HTMLElement to satisfy string: Only a single node is supported');
-        }
-        var originalValue = value;
-        value = documentFragment.childNodes[0];
-        this.argsOutput = function (output) {
-          output.code(originalValue, isHtml ? 'html' : 'xml');
-        };
+      var documentFragment = isHtml ? parseHtml(value, true, this.testDescription) : parseXml(value, this.testDescription);
+      if (documentFragment.childNodes.length !== 1) {
+        throw new Error('HTMLElement to satisfy string: Only a single node is supported');
       }
-      if (expect.findTypeOf(value).name === 'DOMElement') {
-        value = convertDOMNodeToSatisfySpec(value, isHtml);
-      }
-      if (value && typeof value === 'object') {
-        var unsupportedOptions = Object.keys(value).filter(function (key) {
-          return key !== 'attributes' && key !== 'name' && key !== 'children' && key !== 'onlyAttributes' && key !== 'textContent';
-        });
-        if (unsupportedOptions.length > 0) {
-          throw new Error('Unsupported option' + (unsupportedOptions.length === 1 ? '' : 's') + ': ' + unsupportedOptions.join(', '));
-        }
+      expect.argsOutput = function (output) {
+        output.code(value, isHtml ? 'html' : 'xml');
+      };
+      return expect(subject, 'to [exhaustively] satisfy', documentFragment.childNodes[0]);
+    });
+
+    expect.addAssertion('<DOMElement> to [exhaustively] satisfy <DOMElement>', function (expect, subject, value) {
+      return expect(subject, 'to [exhaustively] satisfy', convertDOMNodeToSatisfySpec(value, subject.ownerDocument.contentType === 'text/html'));
+    });
+
+    expect.addAssertion('DOMElement', 'to [exhaustively] satisfy <object>', function (expect, subject, value) {
+      var isHtml = subject.ownerDocument.contentType === 'text/html';
+      var unsupportedOptions = Object.keys(value).filter(function (key) {
+        return key !== 'attributes' && key !== 'name' && key !== 'children' && key !== 'onlyAttributes' && key !== 'textContent';
+      });
+      if (unsupportedOptions.length > 0) {
+        throw new Error('Unsupported option' + (unsupportedOptions.length === 1 ? '' : 's') + ': ' + unsupportedOptions.join(', '));
       }
 
       var promiseByKey = {
@@ -655,7 +653,7 @@ module.exports = {
         attributes: {}
       };
 
-      var onlyAttributes = value && value.onlyAttributes || this.flags.exhaustively;
+      var onlyAttributes = value && value.onlyAttributes || expect.flags.exhaustively;
       var attrs = getAttributes(subject);
       var expectedAttributes = value && value.attributes;
       var expectedAttributeNames = [];
@@ -834,73 +832,74 @@ module.exports = {
       });
     });
 
-    expect.addAssertion('DOMElement', 'to [only] have (attribute|attributes)', function (expect, subject, value) {
-      if (typeof value === 'string') {
-        if (arguments.length > 3) {
-          value = Array.prototype.slice.call(arguments, 2);
-        }
-      } else if (!value || typeof value !== 'object') {
-        throw new Error('to have attributes: Argument must be a string, an array, or an object');
-      }
-      return expect(subject, 'to satisfy', { attributes: value, onlyAttributes: this.flags.only });
+    expect.addAssertion('<DOMElement> to [only] have (attribute|attributes) <string+>', function (expect, subject, value) {
+      return expect(subject, 'to [only] have attributes', Array.prototype.slice.call(arguments, 2));
     });
 
-    expect.addAssertion('DOMElement', 'to have [no] (child|children)', function (expect, subject, query, cmp) {
-      if (this.flags.no) {
-        this.errorMode = 'nested';
-        return expect(Array.prototype.slice.call(subject.childNodes), 'to be an empty array');
-      } else {
-        var children = Array.prototype.slice.call(subject.querySelectorAll(query));
-        throw children;
-      }
+    expect.addAssertion('<DOMElement> to [only] have (attribute|attributes) <array|object>', function (expect, subject, value) {
+      return expect(subject, 'to satisfy', { attributes: value, onlyAttributes: expect.flags.only });
+    });
+
+    expect.addAssertion('<DOMElement> to have no (child|children)', function (expect, subject) {
+      expect.errorMode = 'nested';
+      return expect(Array.prototype.slice.call(subject.childNodes), 'to be an empty array');
+    });
+
+    expect.addAssertion('<DOMElement> to have (child|children)', function (expect, subject) {
+      return expect(subject.childNodes, 'not to be empty');
+    });
+
+    expect.addAssertion('<DOMElement> to have (child|children) <string>', function (expect, subject, query) {
+      expect.errorMode = 'nested';
+      expect(subject.querySelectorAll(query), 'not to be empty');
     });
 
     expect.addAssertion('DOMElement', 'to have text', function (expect, subject, value) {
       return expect(subject.textContent, 'to satisfy', value);
     });
 
-    expect.addAssertion(['DOMDocument', 'DOMElement'], 'queried for [first]', function (expect, subject, value) {
+    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> queried for [first] <string> <any+>', function (expect, subject, query) {
       var queryResult;
 
-      this.errorMode = 'nested';
+      expect.errorMode = 'nested';
 
-      if (this.flags.first) {
-        queryResult = subject.querySelector(value);
+      if (expect.flags.first) {
+        queryResult = subject.querySelector(query);
         if (!queryResult) {
           expect.fail(function (output) {
-            output.error('The selector').sp().jsString(value).sp().error('yielded no results');
+            output.error('The selector').sp().jsString(query).sp().error('yielded no results');
           });
         }
       } else {
-        queryResult = subject.querySelectorAll(value);
+        queryResult = subject.querySelectorAll(query);
         if (queryResult.length === 0) {
           expect.fail(function (output) {
-            output.error('The selector').sp().jsString(value).sp().error('yielded no results');
+            output.error('The selector').sp().jsString(query).sp().error('yielded no results');
           });
         }
       }
-      return this.shift(expect, queryResult, 1);
+      return expect.shift(queryResult, 1);
     });
 
-    expect.addAssertion(['DOMDocument', 'DOMElement'], 'to contain [no] elements matching', function (expect, subject, value) {
-      if (this.flags.no) {
-        return expect(subject.querySelectorAll(value), 'to satisfy', []);
+    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> to contain [no] elements matching <string>', function (expect, subject, query) {
+      if (expect.flags.no) {
+        return expect(subject.querySelectorAll(query), 'to satisfy', []);
       }
-      return expect(subject.querySelectorAll(value), 'not to satisfy', []);
+      return expect(subject.querySelectorAll(query), 'not to satisfy', []);
     });
 
-    expect.addAssertion(['DOMDocument', 'DOMElement'], '[not] to match', function (expect, subject, value) {
-      return expect(matchesSelector(subject, value), 'to be', (this.flags.not ? false : true));
+    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> [not] to match <string>', function (expect, subject, query) {
+      return expect(matchesSelector(subject, query), 'to be', (expect.flags.not ? false : true));
     });
 
-    expect.addAssertion('string', 'when parsed as (html|HTML) [fragment]', function (expect, subject) {
-      this.errorMode = 'nested';
-      return this.shift(expect, parseHtml(subject, this.flags.fragment, this.testDescription), 0);
+    expect.addAssertion('<string> when parsed as (html|HTML) [fragment] <any+>', function (expect, subject) {
+      expect.errorMode = 'nested';
+      return expect.shift(parseHtml(subject, expect.flags.fragment, expect.testDescription), 0);
     });
 
-    expect.addAssertion('string', 'when parsed as (xml|XML)', function (expect, subject) {
-      this.errorMode = 'nested';
-      return this.shift(expect, parseXml(subject, this.testDescription), 0);
+    expect.addAssertion('<string> when parsed as (xml|XML) <any+>', function (expect, subject) {
+      expect.errorMode = 'nested';
+      return expect.shift(parseXml(subject, expect.testDescription), 0);
     });
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -892,7 +892,7 @@ module.exports = {
       return expect(subject.textContent, 'to satisfy', value);
     });
 
-    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> queried for [first] <string> <assertion>', function (expect, subject, query) {
+    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> [when] queried for [first] <string> <assertion?>', function (expect, subject, query) {
       var queryResult;
 
       expect.errorMode = 'nested';
@@ -926,12 +926,12 @@ module.exports = {
       return expect(matchesSelector(subject, query), 'to be', (expect.flags.not ? false : true));
     });
 
-    expect.addAssertion('<string> when parsed as (html|HTML) [fragment] <assertion>', function (expect, subject) {
+    expect.addAssertion('<string> [when] parsed as (html|HTML) [fragment] <assertion?>', function (expect, subject) {
       expect.errorMode = 'nested';
       return expect.shift(parseHtml(subject, expect.flags.fragment, expect.testDescription));
     });
 
-    expect.addAssertion('<string> when parsed as (xml|XML) <assertion>', function (expect, subject) {
+    expect.addAssertion('<string> [when] parsed as (xml|XML) <assertion?>', function (expect, subject) {
       expect.errorMode = 'nested';
       return expect.shift(parseXml(subject, expect.testDescription));
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -620,7 +620,7 @@ module.exports = {
       return expect(subject, 'to [exhaustively] satisfy', convertDOMNodeToSatisfySpec(value, subject.ownerDocument.contentType === 'text/html'));
     });
 
-    expect.addAssertion('DOMElement', 'to [exhaustively] satisfy <object>', function (expect, subject, value) {
+    expect.addAssertion('<DOMElement> to [exhaustively] satisfy <object>', function (expect, subject, value) {
       var isHtml = subject.ownerDocument.contentType === 'text/html';
       var unsupportedOptions = Object.keys(value).filter(function (key) {
         return key !== 'attributes' && key !== 'name' && key !== 'children' && key !== 'onlyAttributes' && key !== 'textContent';
@@ -854,7 +854,7 @@ module.exports = {
       expect(subject.querySelectorAll(query), 'not to be empty');
     });
 
-    expect.addAssertion('DOMElement', 'to have text', function (expect, subject, value) {
+    expect.addAssertion('<DOMElement> to have text <any>', function (expect, subject, value) {
       return expect(subject.textContent, 'to satisfy', value);
     });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -858,7 +858,7 @@ module.exports = {
       return expect(subject.textContent, 'to satisfy', value);
     });
 
-    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> queried for [first] <string> <any+>', function (expect, subject, query) {
+    expect.addAssertion('<DOMDocument|DOMElement|DOMDocumentFragment> queried for [first] <assertion>', function (expect, subject, query) {
       var queryResult;
 
       expect.errorMode = 'nested';
@@ -892,12 +892,12 @@ module.exports = {
       return expect(matchesSelector(subject, query), 'to be', (expect.flags.not ? false : true));
     });
 
-    expect.addAssertion('<string> when parsed as (html|HTML) [fragment] <any+>', function (expect, subject) {
+    expect.addAssertion('<string> when parsed as (html|HTML) [fragment] <assertion>', function (expect, subject) {
       expect.errorMode = 'nested';
       return expect.shift(parseHtml(subject, expect.flags.fragment, expect.testDescription), 0);
     });
 
-    expect.addAssertion('<string> when parsed as (xml|XML) <any+>', function (expect, subject) {
+    expect.addAssertion('<string> when parsed as (xml|XML) <assertion>', function (expect, subject) {
       expect.errorMode = 'nested';
       return expect.shift(parseXml(subject, expect.testDescription), 0);
     });

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "mocha-lcov-reporter": "1.0.0",
     "sinon": "^1.15.4",
     "uglifyjs": "^2.4.10",
-    "unexpected": "9.16.1",
-    "unexpected-sinon": "6.4.1"
+    "unexpected": "10.0.1",
+    "unexpected-sinon": "8.0.0"
   },
   "dependencies": {
     "array-changes": "1.0.3",
@@ -53,6 +53,6 @@
     "magicpen-prism": "^2.1.2"
   },
   "peerDependencies": {
-    "unexpected": "^8.0.0 || ^9.0.0"
+    "unexpected": "^10.0.1"
   }
 }

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -1227,7 +1227,7 @@ describe('unexpected-dom', function () {
         '  <div foo="bar" id="quux">foobar</div>\n' +
         '  <div foo="quux">hey</div>\n' +
         '</body>\n' +
-        'queried for \'div\' to satisfy { 1: { attributes: { foo: \'bar\' } } }\n' +
+        'queried for div to satisfy { 1: { attributes: { foo: \'bar\' } } }\n' +
         '  expected NodeList[ <div foo="bar" id="quux">foobar</div>, <div foo="quux">hey</div> ]\n' +
         '  to satisfy { 1: { attributes: { foo: \'bar\' } } }\n' +
         '\n' +
@@ -1261,7 +1261,7 @@ describe('unexpected-dom', function () {
       expect(function () {
         expect(document.body, 'queried for first', '.blabla', 'to have attributes', { id: 'foo' });
       }, 'to throw',
-        'expected <body><div id="foo"></div></body> queried for first \'.blabla\' to have attributes { id: \'foo\' }\n' +
+        'expected <body><div id="foo"></div></body> queried for first .blabla to have attributes { id: \'foo\' }\n' +
         '  The selector .blabla yielded no results'
       );
     });
@@ -1271,7 +1271,7 @@ describe('unexpected-dom', function () {
       expect(function () {
         expect(document.body, 'queried for', '.blabla', 'to have attributes', { id: 'foo' });
       }, 'to throw',
-        'expected <body><div id="foo"></div></body> queried for \'.blabla\' to have attributes { id: \'foo\' }\n' +
+        'expected <body><div id="foo"></div></body> queried for .blabla to have attributes { id: \'foo\' }\n' +
         '  The selector .blabla yielded no results'
       );
     });
@@ -1294,7 +1294,7 @@ describe('unexpected-dom', function () {
       expect(function () {
         expect(document, 'queried for', 'div', 'to have length', 1);
       }, 'to throw',
-        'expected <!DOCTYPE html><html><head></head><body>...</body></html> queried for \'div\' to have length 1\n' +
+        'expected <!DOCTYPE html><html><head></head><body>...</body></html> queried for div to have length 1\n' +
         '  expected NodeList[ <div></div>, <div></div>, <div></div> ] to have length 1\n' +
         '    expected 3 to be 1'
       );
@@ -1544,7 +1544,7 @@ describe('unexpected-dom', function () {
         'expected \'<!DOCTYPE html><html><body class="bar">foo</body></html>\'\n' +
         'when parsed as HTML queried for first \'body\' to have attributes { class: \'quux\' }\n' +
         '  expected <!DOCTYPE html><html><head></head><body class="bar">...</body></html>\n' +
-        '  queried for first \'body\' to have attributes { class: \'quux\' }\n' +
+        '  queried for first body to have attributes { class: \'quux\' }\n' +
         '    expected <body class="bar">foo</body> to have attributes { class: \'quux\' }\n' +
         '\n' +
         '    <body class="bar" // expected [ \'bar\' ] to contain \'quux\'\n' +

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -1249,6 +1249,13 @@ describe('unexpected-dom', function () {
       expect(document, 'queried for first', 'div', 'to have attributes', { id: 'foo' });
     });
 
+    it('should provide the results as the fulfillment value when no assertion is provided', function () {
+      var document = jsdom.jsdom('<!DOCTYPE html><html><body><div id="foo"></div></body></html>');
+      return expect(document, 'queried for first', 'div').then(function (div) {
+        expect(div, 'to have attributes', { id: 'foo' });
+      });
+    });
+
     it('should error out if the selector matches no elements, first flag set', function () {
       var document = jsdom.jsdom('<!DOCTYPE html><html><body><div id="foo"></div></body></html>');
       expect(function () {
@@ -1505,6 +1512,12 @@ describe('unexpected-dom', function () {
       );
     });
 
+    it('should provide the parsed document as the fulfillment value when no assertion is provided', function () {
+      return expect(htmlSrc, 'parsed as HTML').then(function (document) {
+        expect(document, 'to equal', jsdom.jsdom(htmlSrc));
+      });
+    });
+
     describe('with the "fragment" flag', function () {
       it('should return a DocumentFragment instance', function () {
         expect('<div>foo</div><div>bar</div>', 'when parsed as HTML fragment',
@@ -1515,6 +1528,12 @@ describe('unexpected-dom', function () {
             ]
           )
         );
+      });
+
+      it('should provide the parsed fragment as the fulfillment value when no assertion is provided', function () {
+        return expect('<div>foo</div><div>bar</div>', 'parsed as HTML fragment').then(function (fragment) {
+          expect(fragment, 'to satisfy', [ { children: 'foo' }, { children: 'bar' } ]);
+        });
       });
     });
 
@@ -1532,7 +1551,6 @@ describe('unexpected-dom', function () {
         '    >foo</body>'
       );
     });
-
 
     describe('when the DOMParser global is available', function () {
       var originalDOMParser,
@@ -1609,6 +1627,12 @@ describe('unexpected-dom', function () {
             .and('to equal', jsdom.jsdom(xmlSrc, { parsingMode: 'xml' }))
             .and('queried for first', 'fooBar', 'to have attributes', { yes: 'sir' })
       );
+    });
+
+    it('should provide the parsed document as the fulfillment value when no assertion is provided', function () {
+      return expect('<?xml version="1.0"?><fooBar yes="sir">foo</fooBar>', 'parsed as XML').then(function (document) {
+        expect(document, 'queried for first', 'fooBar', 'to have attributes', { yes: 'sir' });
+      });
     });
 
     describe('when the DOMParser global is available', function () {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -1251,8 +1251,7 @@ describe('unexpected-dom', function () {
       expect(function () {
         expect(document.body, 'queried for first', '.blabla', 'to have attributes', { id: 'foo' });
       }, 'to throw',
-        'expected <body><div id="foo"></div></body>\n' +
-        'queried for first \'.blabla\', \'to have attributes\', { id: \'foo\' }\n' +
+        'expected <body><div id="foo"></div></body> queried for first \'.blabla\' to have attributes { id: \'foo\' }\n' +
         '  The selector .blabla yielded no results'
       );
     });
@@ -1262,7 +1261,7 @@ describe('unexpected-dom', function () {
       expect(function () {
         expect(document.body, 'queried for', '.blabla', 'to have attributes', { id: 'foo' });
       }, 'to throw',
-        'expected <body><div id="foo"></div></body> queried for \'.blabla\', \'to have attributes\', { id: \'foo\' }\n' +
+        'expected <body><div id="foo"></div></body> queried for \'.blabla\' to have attributes { id: \'foo\' }\n' +
         '  The selector .blabla yielded no results'
       );
     });
@@ -1378,14 +1377,14 @@ describe('unexpected-dom', function () {
   });
 
   describe('diffing', function () {
-    expect.addAssertion(['string', 'DOMNode'], 'diffed with', function (expect, subject, value) {
+    expect.addAssertion('<string|DOMNode> diffed with <string|DOMNode> <assertion>', function (expect, subject, value) {
       if (typeof subject === 'string') {
         subject = parseHtml(subject);
       }
       if (typeof value === 'string') {
         value = parseHtml(value);
       }
-      this.shift(expect, expect.diff(subject, value).diff.toString(), 1);
+      return expect.shift(expect.diff(subject, value).diff.toString());
     });
 
     it('should work with HTMLElement', function () {
@@ -1521,7 +1520,7 @@ describe('unexpected-dom', function () {
         expect(htmlSrc, 'when parsed as HTML', 'queried for first', 'body', 'to have attributes', { class: 'quux' });
       }, 'to throw',
         'expected \'<!DOCTYPE html><html><body class="bar">foo</body></html>\'\n' +
-        'when parsed as HTML queried for first \'body\', \'to have attributes\', { class: \'quux\' }\n' +
+        'when parsed as HTML queried for first \'body\' to have attributes { class: \'quux\' }\n' +
         '  expected <!DOCTYPE html><html><head></head><body class="bar">...</body></html>\n' +
         '  queried for first \'body\' to have attributes { class: \'quux\' }\n' +
         '    expected <body class="bar">foo</body> to have attributes { class: \'quux\' }\n' +

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -815,6 +815,40 @@ describe('unexpected-dom', function () {
         });
     });
 
+    describe('with an HTML fragment string passed as the children attribute', function () {
+      it('should succeed', function () {
+        expect('<div foo="bar">foo<span>bar</span></div>', 'when parsed as HTML fragment', 'to satisfy', [
+          {
+            name: 'div',
+            children: 'foo<span>bar</span>'
+          }
+        ]);
+      });
+
+      it('should fail with a diff', function () {
+        expect(function () {
+          expect('<div foo="bar">foo<span>bar</span></div>', 'when parsed as HTML fragment', 'to satisfy', [
+            {
+              name: 'div',
+              children: '<span>bar</span>foo'
+            }
+          ]);
+        }, 'to throw',
+          'expected \'<div foo="bar">foo<span>bar</span></div>\'\n' +
+          'when parsed as HTML fragment to satisfy [ { name: \'div\', children: \'<span>bar</span>foo\' } ]\n' +
+          '  expected DocumentFragment[NodeList[ <div foo="bar">foo<span>...</span></div> ]]\n' +
+          '  to satisfy [ { name: \'div\', children: \'<span>bar</span>foo\' } ]\n' +
+          '\n' +
+          '  NodeList[\n' +
+          '    <div foo="bar">\n' +
+          '      foo // should satisfy { name: \'span\', attributes: {}, children: [ \'bar\' ] }\n' +
+          '      <span>bar</span> // should satisfy \'foo\'\n' +
+          '    </div>\n' +
+          '  ]'
+        );
+      });
+    });
+
     describe('HTMLFragment', function () {
       describe('with a string as the value', function () {
         it('should succeed', function () {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -6,24 +6,27 @@ var unexpected = require('unexpected'),
 
 var expect = unexpected.clone().installPlugin(require('unexpected-sinon')).installPlugin(unexpectedDom);
 
-expect.addAssertion('to inspect as [itself]', function (expect, subject, value) {
+expect.addAssertion('<any> to inspect as itself', function (expect, subject) {
   var originalSubject = subject;
   if (typeof subject === 'string') {
     subject = jsdom.jsdom('<!DOCTYPE html><html><head></head><body>' + subject + '</body></html>').body.firstChild;
   }
-  if (this.flags.itself) {
-    if (typeof originalSubject === 'string') {
-      expect(expect.inspect(subject).toString(), 'to equal', originalSubject);
-    } else {
-      throw new Error('subject must be given as a string when expected to inspect as itself');
-    }
+  if (typeof originalSubject === 'string') {
+    expect(expect.inspect(subject).toString(), 'to equal', originalSubject);
   } else {
-    expect(expect.inspect(subject).toString(), 'to equal', value);
+    throw new Error('subject must be given as a string when expected to inspect as itself');
   }
 });
 
-expect.addAssertion('to produce a diff of', function (expect, subject, value) {
-  this.errorMode = 'bubble';
+expect.addAssertion('<any> to inspect as <string>', function (expect, subject, value) {
+  if (typeof subject === 'string') {
+    subject = jsdom.jsdom('<!DOCTYPE html><html><head></head><body>' + subject + '</body></html>').body.firstChild;
+  }
+  expect(expect.inspect(subject).toString(), 'to equal', value);
+});
+
+expect.addAssertion('<array> to produce a diff of <string>', function (expect, subject, value) {
+  expect.errorMode = 'bubble';
   subject = subject.map(function (item) {
     return typeof item === 'string' ? jsdom.jsdom('<!DOCTYPE html><html><head></head><body>' + item + '</body></html>').body.firstChild : item;
   });
@@ -1377,7 +1380,7 @@ describe('unexpected-dom', function () {
   });
 
   describe('diffing', function () {
-    expect.addAssertion('<string|DOMNode> diffed with <string|DOMNode> <assertion>', function (expect, subject, value) {
+    expect.addAssertion('<string|DOMNode|DOMDocument> diffed with <string|DOMNode|DOMDocument> <assertion>', function (expect, subject, value) {
       if (typeof subject === 'string') {
         subject = parseHtml(subject);
       }


### PR DESCRIPTION
Cuts compatibility with Unexpected 9 and below, sorry.

Bonus features:

* when parsed as, when queried for: Make 'when' optional and provide the result as the fulfillment value if no assertion is provided.
* Add support for satisfying DOMNodeList against strings and DOMNodeList. Exploit it to support `expect(domElement, 'to satisfy', children: 'foo<span>bar</span>');`
* queried for: Don't put CSS selectors in quotes in the error messages