### PR TITLE
Work in Progress: allow to assert on single-child elements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -897,6 +897,10 @@ module.exports = {
       expect(subject.querySelectorAll(query), 'not to be empty');
     });
 
+    expect.exportAssertion('<DOMElement> to have a single child', function (expect, subject) {
+      expect(subject.childNodes.length, 'to be', 1);
+    });
+
     expect.exportAssertion('<DOMElement> to have text <any>', function (expect, subject, value) {
       return expect(subject.textContent, 'to satisfy', value);
     });

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -849,6 +849,36 @@ describe('unexpected-dom', function () {
         }, 'to throw', /^expected <div>I am a text<\/div> to have no children/);
       });
     });
+
+  });
+
+  describe('to have a single child', function () {
+    it('should pass for element with single child', function () {
+      this.body.innerHTML = '<div><hr /></div>';
+      var el = this.body.firstChild;
+
+      expect(function () {
+        expect(el, 'to have a single child');
+      }, 'not to throw');
+    });
+
+    it('should throw for element with no children', function () {
+      this.body.innerHTML = '<div></div>';
+      var el = this.body.firstChild;
+
+      expect(function () {
+        expect(el, 'to have a single child');
+      }, 'to throw', 'expected <div></div> to have a single child');
+    });
+
+    it('should throw for element with multiple children', function () {
+      this.body.innerHTML = '<div><br><br><br></div>';
+      var el = this.body.firstChild;
+
+      expect(function () {
+        expect(el, 'to have a single child');
+      }, 'to throw', 'expected <div><br><br><br></div> to have a single child');
+    });
   });
 
   describe('to satisfy', function () {


### PR DESCRIPTION
The README says:

> Assertions that test none, singular an plural of a possible collection generally work in all the forms ou would expect. For example to have no children, to have child, to have children.

but (besides being a bit hard to parse ;)) I couldn't figure out how to assert for things matching single results... I think the assertions are missing and added on example. Some other things could be:

```
expect(e, 'to have a single child matching', selector);
expect(e, 'when queried for only', selector);
// TODO oops, gotta run to a catch a train but I think there could be more things missing unless I just don't see an easy way to compose with an array expectation or something
```