### PR TITLE
Added a `not to have (attribute|attributes)` assertion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ expect(node, 'to [only] have attributes', {
 });
 ```
 
+**Not to have attributes**
+
+```js
+expect(node, 'not to have attribute', 'id');
+expect(node, 'not to have attributes', 'id', 'class');
+expect(node, 'not to have attributes', ['id', 'class']);
+```
+
 **To have text**
 
 Tests the text content of a DOM element

--- a/lib/index.js
+++ b/lib/index.js
@@ -879,6 +879,20 @@ module.exports = {
       return expect(subject, 'to [only] have attributes', Array.prototype.slice.call(arguments, 2));
     });
 
+    expect.exportAssertion('<DOMElement> not to have (attribute|attributes) <array>', function (expect, subject, value) {
+      var attributes = getAttributes(subject);
+
+      value.forEach(function (name) {
+        delete attributes[name];
+      });
+
+      return expect(subject, 'to only have attributes', attributes);
+    });
+
+    expect.exportAssertion('<DOMElement> not to have (attribute|attributes) <string+>', function (expect, subject, value) {
+      return expect(subject, 'not to have attributes', Array.prototype.slice.call(arguments, 2));
+    });
+
     expect.exportAssertion('<DOMElement> to [only] have (attribute|attributes) <array|object>', function (expect, subject, value) {
       return expect(subject, 'to satisfy', { attributes: value, onlyAttributes: expect.flags.only });
     });

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -808,7 +808,90 @@ describe('unexpected-dom', function () {
               });
             }, 'to throw', /to only have attributes \{ style: \{ background: 'blue' \} \}/);
           });
-        });
+        })
+;
+      });
+    });
+  });
+
+  describe('not to have attributes', function () {
+    describe('when given one of more strings', function () {
+      it('should pass if the given element does not have any the provided attribute names', function () {
+        body.innerHTML = '<div style="color: red; background: blue" />';
+        var node = body.firstChild;
+
+        expect(node, 'not to have attributes', 'data-test-id', 'class');
+      });
+
+      it('should fail if the given element has one of the provided attributes', function () {
+        body.innerHTML = '<div style="color: red; background: blue" class="my-class"/>';
+        var node = body.firstChild;
+
+        expect(function () {
+          expect(node, 'not to have attributes', 'data-test-id', 'class');
+        }, 'to throw', [
+          'expected <div class="my-class" style="color: red; background: blue"></div>',
+          'not to have attributes \'data-test-id\', \'class\'',
+          '',
+          '<div style="color: red; background: blue" class="my-class" // should be removed',
+          '></div>'
+        ].join('\n'));
+      });
+
+      it('should fail if the given element has multiple of the provided attributes', function () {
+        body.innerHTML = '<div data-test-id="my-div" style="color: red; background: blue" class="my-class"/>';
+        var node = body.firstChild;
+
+        expect(function () {
+          expect(node, 'not to have attributes', 'data-test-id', 'class');
+        }, 'to throw', [
+          'expected <div class="my-class" data-test-id="my-div" style="color: red; background: blue"></div>',
+          'not to have attributes \'data-test-id\', \'class\'',
+          '',
+          '<div data-test-id="my-div" // should be removed',
+          '     style="color: red; background: blue" class="my-class" // should be removed',
+          '></div>'
+        ].join('\n'));
+      });
+    });
+
+    describe('when given an array', function () {
+      it('should pass if the given element does not have any of the provided attribute names', function () {
+        body.innerHTML = '<div style="color: red; background: blue" />';
+        var node = body.firstChild;
+
+        expect(node, 'not to have attributes', ['data-test-id', 'class']);
+      });
+
+      it('should fail if the given element has one of the provided attributes', function () {
+        body.innerHTML = '<div style="color: red; background: blue" class="my-class"/>';
+        var node = body.firstChild;
+
+        expect(function () {
+          expect(node, 'not to have attributes', ['data-test-id', 'class']);
+        }, 'to throw', [
+          'expected <div class="my-class" style="color: red; background: blue"></div>',
+          'not to have attributes [ \'data-test-id\', \'class\' ]',
+          '',
+          '<div style="color: red; background: blue" class="my-class" // should be removed',
+          '></div>'
+        ].join('\n'));
+      });
+
+      it('should fail if the given element has multiple of the provided attributes', function () {
+        body.innerHTML = '<div data-test-id="my-div" style="color: red; background: blue" class="my-class"/>';
+        var node = body.firstChild;
+
+        expect(function () {
+          expect(node, 'not to have attributes', ['data-test-id', 'class']);
+        }, 'to throw', [
+          'expected <div class="my-class" data-test-id="my-div" style="color: red; background: blue"></div>',
+          'not to have attributes [ \'data-test-id\', \'class\' ]',
+          '',
+          '<div data-test-id="my-div" // should be removed',
+          '     style="color: red; background: blue" class="my-class" // should be removed',
+          '></div>'
+        ].join('\n'));
       });
     });
   });


### PR DESCRIPTION
This is useful to testing that a button is not disabled.

```js
expect(button, 'not to have attribute', 'disabled')
```