### PR TITLE
Fully inspect subject when contain elements matching fails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1375,6 +1375,10 @@ module.exports = {
         if (expect.flags.no) {
           return expect(subject.querySelectorAll(query), 'to satisfy', []);
         }
+
+        expect.subjectOutput = function(output) {
+          expect.inspect(subject, Infinity, output);
+        };
         return expect(subject.querySelectorAll(query), 'not to satisfy', []);
       }
     );

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -1908,7 +1908,14 @@ describe('unexpected-dom', function() {
           expect(document, 'to contain elements matching', '.bar');
         },
         'to throw',
-        "expected <!DOCTYPE html><html><head></head><body>...</body></html> to contain elements matching '.bar'"
+        [
+          'expected',
+          '<!DOCTYPE html><html>',
+          '  <head></head>',
+          '  <body><div class="foo"></div><div class="foo"></div></body>',
+          '</html>',
+          "to contain elements matching '.bar'"
+        ].join('\n')
       );
     });
   });


### PR DESCRIPTION
When `to contain elements matching` fails you usually don't get the details you need as the inspected output dot out sub trees deeper than 3 levels.  