### PR TITLE
Support ignoring subtrees in to satisfy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -738,7 +738,10 @@ module.exports = {
     );
 
     function convertDOMNodeToSatisfySpec(node, isHtml) {
-      if (node.nodeType === 10) {
+      if (node.nodeType === 8 && node.nodeValue.trim() === 'ignore') {
+        // Ignore subtree
+        return {};
+      } else if (node.nodeType === 10) {
         // HTMLDocType
         return { name: node.nodeName };
       } else if (node.nodeType === 1) {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -1293,6 +1293,50 @@ describe('unexpected-dom', function() {
               '  ]'
           );
         });
+
+        describe('and it contain an <ignore/> tag', function() {
+          it('ignores that subtree', () => {
+            expect(
+              '<div foo="bar">foo</div><div><div>bar</div></div><div>baz</div>',
+              'when parsed as HTML fragment to satisfy',
+              parseHtmlFragment(
+                '<div foo="bar">foo</div><!--ignore--><div>baz</div>'
+              )
+            );
+          });
+
+          it('inspects correctly when another subtree', function() {
+            expect(
+              function() {
+                expect(
+                  '<div foo="bar">foo</div><div><div>bar</div></div><div>baz</div>',
+                  'when parsed as HTML fragment to satisfy',
+                  parseHtmlFragment(
+                    '<div foo="bar">foo!</div><!--ignore--><div>baz</div>'
+                  )
+                );
+              },
+              'to throw',
+              [
+                'expected \'<div foo="bar">foo</div><div><div>bar</div></div><div>baz</div>\'',
+                'when parsed as HTML fragment to satisfy DocumentFragment[NodeList[ <div foo="bar">foo!</div>, <!--ignore-->, <div>baz</div> ]]',
+                '  expected DocumentFragment[NodeList[ <div foo="bar">foo</div>, <div><div>...</div></div>, <div>baz</div> ]]',
+                '  to satisfy DocumentFragment[NodeList[ <div foo="bar">foo!</div>, <!--ignore-->, <div>baz</div> ]]',
+                '',
+                '  NodeList[',
+                '    <div foo="bar">',
+                "      foo // should equal 'foo!'",
+                '          //',
+                '          // -foo',
+                '          // +foo!',
+                '    </div>,',
+                '    <div><div>...</div></div>,',
+                '    <div>baz</div>',
+                '  ]'
+              ].join('\n')
+            );
+          });
+        });
       });
 
       describe('with an array as the value', function() {

--- a/test/unexpected-dom.js
+++ b/test/unexpected-dom.js
@@ -1297,10 +1297,14 @@ describe('unexpected-dom', function() {
         describe('and it contain an <ignore/> tag', function() {
           it('ignores that subtree', () => {
             expect(
-              '<div foo="bar">foo</div><div><div>bar</div></div><div>baz</div>',
+              [
+                '<div foo="bar">foo</div>',
+                '<div><div>bar</div></div>',
+                '<div>baz</div>'
+              ].join('\n'),
               'when parsed as HTML fragment to satisfy',
               parseHtmlFragment(
-                '<div foo="bar">foo</div><!--ignore--><div>baz</div>'
+                ['<div>foo</div>', '<!--ignore-->', '<div>baz</div>'].join('\n')
               )
             );
           });


### PR DESCRIPTION
You need to use a special comment `<!--ignore-->` on the rhs. That was the least intrusive solution I could come up with. Using an `<ignore/>` element does not work as it is not a void element, so you would have to type `<ignore></ignore>` - that is a little too much ignore :-)