### PR TITLE
Add support for an ignore tag in addition to the ignore tag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -745,9 +745,15 @@ module.exports = {
         return { name: node.nodeName };
       } else if (node.nodeType === 1) {
         // DOMElement
-        var result = {
-          name: isHtml ? node.nodeName.toLowerCase() : node.nodeName
-        };
+        var name = isHtml ? node.nodeName.toLowerCase() : node.nodeName;
+
+        if (name === 'ignore') {
+          // Ignore subtree
+          return {};
+        }
+
+        var result = { name: name };
+
         if (node.attributes) {
           result.attributes = {};
           for (var i = 0; i < node.attributes.length; i += 1) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1387,7 +1387,7 @@ describe('unexpected-dom', function() {
           );
         });
 
-        describe('and it contain an <ignore/> tag', function() {
+        describe('and it contain an ignore comment', function() {
           it('ignores that subtree', () => {
             expect(
               [
@@ -1419,6 +1419,56 @@ describe('unexpected-dom', function() {
                 'when parsed as HTML fragment to satisfy DocumentFragment[NodeList[ <div foo="bar">foo!</div>, <!--ignore-->, <div>baz</div> ]]',
                 '  expected DocumentFragment[NodeList[ <div foo="bar">foo</div>, <div><div>...</div></div>, <div>baz</div> ]]',
                 '  to satisfy DocumentFragment[NodeList[ <div foo="bar">foo!</div>, <!--ignore-->, <div>baz</div> ]]',
+                '',
+                '  NodeList[',
+                '    <div foo="bar">',
+                "      foo // should equal 'foo!'",
+                '          //',
+                '          // -foo',
+                '          // +foo!',
+                '    </div>,',
+                '    <div><div>...</div></div>,',
+                '    <div>baz</div>',
+                '  ]'
+              ].join('\n')
+            );
+          });
+        });
+
+        describe('and it contain an ignore tag', function() {
+          it('ignores that subtree', () => {
+            expect(
+              [
+                '<div foo="bar">foo</div>',
+                '<div><div>bar</div></div>',
+                '<div>baz</div>'
+              ].join('\n'),
+              'when parsed as HTML fragment to satisfy',
+              parseHtmlFragment(
+                ['<div>foo</div>', '<ignore></ignore>', '<div>baz</div>'].join(
+                  '\n'
+                )
+              )
+            );
+          });
+
+          it('inspects correctly when another subtree', function() {
+            expect(
+              function() {
+                expect(
+                  '<div foo="bar">foo</div><div><div>bar</div></div><div>baz</div>',
+                  'when parsed as HTML fragment to satisfy',
+                  parseHtmlFragment(
+                    '<div foo="bar">foo!</div><ignore></ignore><div>baz</div>'
+                  )
+                );
+              },
+              'to throw',
+              [
+                'expected \'<div foo="bar">foo</div><div><div>bar</div></div><div>baz</div>\'',
+                'when parsed as HTML fragment to satisfy DocumentFragment[NodeList[ <div foo="bar">foo!</div>, <ignore></ignore>, <div>baz</div> ]]',
+                '  expected DocumentFragment[NodeList[ <div foo="bar">foo</div>, <div><div>...</div></div>, <div>baz</div> ]]',
+                '  to satisfy DocumentFragment[NodeList[ <div foo="bar">foo!</div>, <ignore></ignore>, <div>baz</div> ]]',
                 '',
                 '  NodeList[',
                 '    <div foo="bar">',


### PR DESCRIPTION
This is useful for testing React components with unexpected-dom as you can't
produce a comment in JSX.

This is still a feature (undocumented) until I have tested it in real
applications.